### PR TITLE
Adds a bytes output mode.

### DIFF
--- a/cmd/substreams/run.go
+++ b/cmd/substreams/run.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
+
 	"github.com/spf13/cobra"
 	"github.com/streamingfast/cli"
 	"github.com/streamingfast/cli/sflags"
@@ -14,7 +16,6 @@ import (
 	"github.com/streamingfast/substreams/tui"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/metadata"
-	"io"
 )
 
 func init() {
@@ -28,7 +29,7 @@ func init() {
 	runCmd.Flags().Bool("final-blocks-only", false, "Only process blocks that have pass finality, to prevent any reorg and undo signal by staying further away from the chain HEAD")
 	runCmd.Flags().Bool("insecure", false, "Skip certificate validation on GRPC connection")
 	runCmd.Flags().Bool("plaintext", false, "Establish GRPC connection in plaintext")
-	runCmd.Flags().StringP("output", "o", "", "Output mode. Defaults to 'ui' when in a TTY is present, and 'json' otherwise")
+	runCmd.Flags().StringP("output", "o", "", "Output mode: ['ui', 'json', 'bytes']. Defaults to 'ui' when in a TTY is present, and 'json' otherwise")
 	runCmd.Flags().StringSlice("debug-modules-initial-snapshot", nil, "List of 'store' modules from which to print the initial data snapshot (Unavailable in Production Mode)")
 	runCmd.Flags().StringSlice("debug-modules-output", nil, "List of modules from which to print outputs, deltas and logs (Unavailable in Production Mode)")
 	runCmd.Flags().StringSliceP("header", "H", nil, "Additional headers to be sent in the substreams request")
@@ -229,7 +230,6 @@ func runRun(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			if err == io.EOF {
 				ui.Cancel()
-				fmt.Println("all done")
 				if testRunner != nil {
 					testRunner.LogResults()
 				}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -19,7 +19,7 @@ import (
 
 //go:generate go-enum -f=$GOFILE --nocase --marshal --names
 
-// ENUM(TUI, JSON, JSONL)
+// ENUM(TUI, JSON, JSONL, BYTES)
 type OutputMode uint
 
 type TUI struct {

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -121,6 +121,7 @@ func (ui *TUI) configureOutputMode(outputMode string) error {
 	case OutputModeJSONL:
 	case OutputModeJSON:
 		ui.prettyPrintOutput = true
+	case OutputModeBytes:
 	default:
 		panic(fmt.Errorf("unhandled output mode %q", ui.outputMode))
 	}
@@ -167,6 +168,8 @@ func (ui *TUI) IncomingMessage(ctx context.Context, resp *pbsubstreamsrpc.Respon
 		if ui.outputMode == OutputModeTUI {
 			ui.ensureTerminalUnlocked()
 			return ui.decoratedBlockScopedData(m.BlockScopedData.Output, m.BlockScopedData.DebugMapOutputs, m.BlockScopedData.DebugStoreOutputs, m.BlockScopedData.Clock)
+		} else if ui.outputMode == OutputModeBytes {
+			return ui.bytesBlockScopedData(m.BlockScopedData.Output, m.BlockScopedData.DebugMapOutputs, m.BlockScopedData.DebugStoreOutputs, m.BlockScopedData.Clock)
 		} else {
 			return ui.jsonBlockScopedData(m.BlockScopedData.Output, m.BlockScopedData.DebugMapOutputs, m.BlockScopedData.DebugStoreOutputs, m.BlockScopedData.Clock)
 		}
@@ -194,7 +197,8 @@ func (ui *TUI) IncomingMessage(ctx context.Context, resp *pbsubstreamsrpc.Respon
 		if ui.outputMode == OutputModeTUI {
 			ui.ensureTerminalLocked()
 			ui.prog.Send(m)
-		} else {
+		} else if ui.outputMode != OutputModeBytes {
+			// avoid printing this so it can be piped easily into a file.
 			fmt.Printf("TraceID: %s\n", m.Session.TraceId)
 		}
 

--- a/tui/tui_enum.go
+++ b/tui/tui_enum.go
@@ -18,8 +18,8 @@ const (
 	OutputModeJSON
 	// OutputModeJSONL is a OutputMode of type JSONL.
 	OutputModeJSONL
-	// Pure protobuf bytes
-	OutputModeBytes
+	// OutputModeBYTES is a OutputMode of type BYTES.
+	OutputModeBYTES
 )
 
 var ErrInvalidOutputMode = fmt.Errorf("not a valid OutputMode, try [%s]", strings.Join(_OutputModeNames, ", "))
@@ -44,7 +44,7 @@ var _OutputModeMap = map[OutputMode]string{
 	OutputModeTUI:   _OutputModeName[0:3],
 	OutputModeJSON:  _OutputModeName[3:7],
 	OutputModeJSONL: _OutputModeName[7:12],
-	OutputModeBytes: _OutputModeName[12:17],
+	OutputModeBYTES: _OutputModeName[12:17],
 }
 
 // String implements the Stringer interface.
@@ -63,14 +63,14 @@ func (x OutputMode) IsValid() bool {
 }
 
 var _OutputModeValue = map[string]OutputMode{
-	_OutputModeName[0:3]:                   OutputModeTUI,
-	strings.ToLower(_OutputModeName[0:3]):  OutputModeTUI,
-	_OutputModeName[3:7]:                   OutputModeJSON,
-	strings.ToLower(_OutputModeName[3:7]):  OutputModeJSON,
-	_OutputModeName[7:12]:                  OutputModeJSONL,
-	strings.ToLower(_OutputModeName[7:12]): OutputModeJSONL,
-	_OutputModeName[12:17]: OutputModeBytes,
-	strings.ToLower(_OutputModeName[12:17]): OutputModeBytes,
+	_OutputModeName[0:3]:                    OutputModeTUI,
+	strings.ToLower(_OutputModeName[0:3]):   OutputModeTUI,
+	_OutputModeName[3:7]:                    OutputModeJSON,
+	strings.ToLower(_OutputModeName[3:7]):   OutputModeJSON,
+	_OutputModeName[7:12]:                   OutputModeJSONL,
+	strings.ToLower(_OutputModeName[7:12]):  OutputModeJSONL,
+	_OutputModeName[12:17]:                  OutputModeBYTES,
+	strings.ToLower(_OutputModeName[12:17]): OutputModeBYTES,
 }
 
 // ParseOutputMode attempts to convert a string to a OutputMode.

--- a/tui/tui_enum.go
+++ b/tui/tui_enum.go
@@ -18,16 +18,19 @@ const (
 	OutputModeJSON
 	// OutputModeJSONL is a OutputMode of type JSONL.
 	OutputModeJSONL
+	// Pure protobuf bytes
+	OutputModeBytes
 )
 
 var ErrInvalidOutputMode = fmt.Errorf("not a valid OutputMode, try [%s]", strings.Join(_OutputModeNames, ", "))
 
-const _OutputModeName = "TUIJSONJSONL"
+const _OutputModeName = "TUIJSONJSONLBYTES"
 
 var _OutputModeNames = []string{
 	_OutputModeName[0:3],
 	_OutputModeName[3:7],
 	_OutputModeName[7:12],
+	_OutputModeName[12:17],
 }
 
 // OutputModeNames returns a list of possible string values of OutputMode.
@@ -41,6 +44,7 @@ var _OutputModeMap = map[OutputMode]string{
 	OutputModeTUI:   _OutputModeName[0:3],
 	OutputModeJSON:  _OutputModeName[3:7],
 	OutputModeJSONL: _OutputModeName[7:12],
+	OutputModeBytes: _OutputModeName[12:17],
 }
 
 // String implements the Stringer interface.
@@ -65,6 +69,8 @@ var _OutputModeValue = map[string]OutputMode{
 	strings.ToLower(_OutputModeName[3:7]):  OutputModeJSON,
 	_OutputModeName[7:12]:                  OutputModeJSONL,
 	strings.ToLower(_OutputModeName[7:12]): OutputModeJSONL,
+	_OutputModeName[12:17]: OutputModeBytes,
+	strings.ToLower(_OutputModeName[12:17]): OutputModeBytes,
 }
 
 // ParseOutputMode attempts to convert a string to a OutputMode.


### PR DESCRIPTION
This mode will simply output a protobuf message as b64 encoded bytes.

This is useful to create unittest test cases for handler functions.